### PR TITLE
Fix debug_traceBlock rlp block decoding

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -452,7 +452,7 @@ func (api *API) TraceBlockByHash(ctx context.Context, hash common.Hash, config *
 
 // TraceBlock returns the structured logs created during the execution of EVM
 // and returns them as a JSON object.
-func (api *API) TraceBlock(ctx context.Context, blob []byte, config *TraceConfig) ([]*txTraceResult, error) {
+func (api *API) TraceBlock(ctx context.Context, blob hexutil.Bytes, config *TraceConfig) ([]*txTraceResult, error) {
 	block := new(types.Block)
 	if err := rlp.Decode(bytes.NewReader(blob), block); err != nil {
 		return nil, fmt.Errorf("could not decode block: %v", err)


### PR DESCRIPTION
`debug_traceBlock` wasn't usable over RPC because the RLP block JSON input isn't being Unmarshalled.

See the bug using the geth console: 

```

> var rlp = debug.getBlockRlp(<ANY BLOCK NUMBER>)

> debug.traceBlock(rlp)
Error: could not decode block: rlp: expected input list for types.Header, decoding into (types.Block)(types.extblock).Header
	at web3.js:6365:37(47)
	at send (web3.js:5099:62(35))
	at <eval>:1:17(4)
```

With the fix, the above commands work. 

